### PR TITLE
Increase Node.js heap size for build script to 512MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:simple-backend": "node simple-backend.cjs",
     "dev:both": "node run-both.cjs",
     "dev:full": "concurrently \"npm run dev\" \"npm run dev:backend\"",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=256 vite build && cross-env NODE_OPTIONS=--max-old-space-size=256 node scripts/optimize-build.js",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=512 vite build && cross-env NODE_OPTIONS=--max-old-space-size=512 node scripts/optimize-build.js",
     "build:pwa": "cross-env NODE_OPTIONS=--max-old-space-size=384 node scripts/memory-optimized-build.cjs",
     "build:minimal": "cross-env NODE_OPTIONS=--max-old-space-size=300 node scripts/minimal-build.cjs",
     "build:check": "cross-env NODE_OPTIONS=--max-old-space-size=384 tsc -b && cross-env NODE_OPTIONS=--max-old-space-size=384 vite build && cross-env NODE_OPTIONS=--max-old-space-size=384 node scripts/optimize-build.js",


### PR DESCRIPTION
## Purpose

The user encountered a JavaScript heap out of memory error during the build process. The build was failing with a "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory" message, indicating that the allocated 256MB heap size was insufficient for the Vite build and optimization processes.

## Code changes

- Updated the `build` script in `package.json` to increase the Node.js heap size from 256MB to 512MB
- Modified both the Vite build command and the optimize-build script to use the new memory allocation
- This change doubles the available memory for the build process to prevent out-of-memory errors

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1321cca295f647e7b45bc63083fbe6e3/spark-lab)

👀 [Preview Link](https://1321cca295f647e7b45bc63083fbe6e3-spark-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1321cca295f647e7b45bc63083fbe6e3</projectId>-->
<!--<branchName>spark-lab</branchName>-->