### PR TITLE
Fix: Show assigned vendor and auto-update order status

### DIFF
--- a/backend/routes/vendor-orders.js
+++ b/backend/routes/vendor-orders.js
@@ -288,6 +288,17 @@ router.put("/orders/:orderId/status", verifyVendorToken, async (req, res) => {
       vendor_id: req.vendor_id,
     });
 
+    // Auto-transition to in_progress after pickup_completed
+    if (status === "pickup_completed") {
+      order.status = "in_progress";
+      order.status_history.push({
+        status: "in_progress",
+        changed_at: order.updated_at,
+        changed_by: "system",
+        vendor_id: req.vendor_id,
+      });
+    }
+
     await order.save();
 
     console.log(`✅ Order status updated: ${orderId} -> ${status}`);

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -885,10 +885,10 @@ const AdminBookingManagement: React.FC = () => {
                           <Phone className="h-4 w-4 text-gray-400" />
                           <span className="text-sm">{booking.phone}</span>
                         </div>
-                        {booking.vendor && (
+                        {booking.assignedVendor && (
                           <div className="flex items-center gap-2">
                             <Store className="h-4 w-4 text-gray-400" />
-                            <span className="text-sm text-green-700">{booking.vendor}</span>
+                            <span className="text-sm text-green-700">{booking.assignedVendor}</span>
                           </div>
                         )}
                       </div>
@@ -982,10 +982,10 @@ const AdminBookingManagement: React.FC = () => {
                           <User className="h-4 w-4 text-gray-400" />
                           <span className="text-sm">{booking.name}</span>
                         </div>
-                        {booking.vendor && (
+                        {booking.assignedVendor && (
                           <div className="flex items-center gap-2 mt-1">
                             <Store className="h-4 w-4 text-gray-400" />
-                            <span className="text-sm text-green-700">{booking.vendor}</span>
+                            <span className="text-sm text-green-700">{booking.assignedVendor}</span>
                           </div>
                         )}
                       </div>

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -300,18 +300,15 @@ const formatScheduledDateTime = (booking: Booking): string => {
     const dateObj = new Date(dateStr);
     const [hours, minutes] = timeStr.split(':').map(Number);
 
-    const formatted = dateObj.toLocaleString('en-IN', {
+    const dayMonth = dateObj.toLocaleString('en-IN', {
       timeZone: 'Asia/Kolkata',
       day: 'numeric',
       month: 'short',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true
+      year: 'numeric'
     });
 
     if (!timeStr || timeStr === '00:00') {
-      return formatted.split(' at ')[0] || formatted;
+      return dayMonth;
     }
 
     const timeFormatted = new Date(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate(), hours, minutes)
@@ -322,9 +319,9 @@ const formatScheduledDateTime = (booking: Booking): string => {
         hour12: true
       });
 
-    return `${formatted.split(' at ')[0]}, ${timeFormatted}`;
+    return `${dayMonth}, ${timeFormatted}`;
   } catch (e) {
-    return formatDateTimeIST(booking.scheduled_date);
+    return formatDateOnlyIST(booking.scheduled_date);
   }
 };
 
@@ -514,7 +511,7 @@ const AdminBookingManagement: React.FC = () => {
       es.addEventListener('booking_change', (event: MessageEvent) => {
         try {
           const payload = JSON.parse(event.data);
-          console.log('🔔 Received booking_change SSE payload:', payload?._id || payload);
+          console.log('��� Received booking_change SSE payload:', payload?._id || payload);
           if (payload && payload._id && !showEditDialog) {
             applyBookingUpdate(payload._id, payload);
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1059,7 +1059,7 @@ const AdminBookingManagement: React.FC = () => {
                         </div>
                         <div className="flex items-center gap-2 text-sm text-gray-600">
                           <Calendar className="h-4 w-4" />
-                          {formatDate(booking.delivery_date || booking.scheduled_date)}
+                          {booking.delivery_date ? formatScheduledDateTime({...booking, scheduled_date: booking.delivery_date, scheduled_time: booking.delivery_time || '00:00'} as Booking) : formatScheduledDateTime(booking)}
                         </div>
                       </div>
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -274,6 +274,60 @@ const formatDate = (dateString?: string | Date) => {
   return formatDateTimeIST(dateString as any);
 };
 
+const getScheduledDateTime = (booking: Booking): Date => {
+  try {
+    const dateStr = booking.scheduled_date || '';
+    const timeStr = booking.scheduled_time || '00:00';
+
+    if (!dateStr) return new Date(0);
+
+    const [hours, minutes] = timeStr.split(':').map(Number);
+    const dateObj = new Date(dateStr);
+    dateObj.setHours(hours || 0, minutes || 0, 0, 0);
+    return dateObj;
+  } catch (e) {
+    return new Date(0);
+  }
+};
+
+const formatScheduledDateTime = (booking: Booking): string => {
+  try {
+    const dateStr = booking.scheduled_date || '';
+    const timeStr = booking.scheduled_time || '00:00';
+
+    if (!dateStr) return 'N/A';
+
+    const dateObj = new Date(dateStr);
+    const [hours, minutes] = timeStr.split(':').map(Number);
+
+    const formatted = dateObj.toLocaleString('en-IN', {
+      timeZone: 'Asia/Kolkata',
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true
+    });
+
+    if (!timeStr || timeStr === '00:00') {
+      return formatted.split(' at ')[0] || formatted;
+    }
+
+    const timeFormatted = new Date(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate(), hours, minutes)
+      .toLocaleString('en-IN', {
+        timeZone: 'Asia/Kolkata',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      });
+
+    return `${formatted.split(' at ')[0]}, ${timeFormatted}`;
+  } catch (e) {
+    return formatDateTimeIST(booking.scheduled_date);
+  }
+};
+
 const StatusFlowIndicator: React.FC<{ currentStatus: string; className?: string }> = ({
   currentStatus,
   className,
@@ -472,7 +526,7 @@ const AdminBookingManagement: React.FC = () => {
       });
 
       es.onerror = (err) => {
-        console.warn('⚠️ SSE connection error:', err);
+        console.warn('⚠�� SSE connection error:', err);
         try { es && es.close(); } catch (e) { }
       };
     } catch (e) {
@@ -567,6 +621,12 @@ const AdminBookingManagement: React.FC = () => {
     if (statusFilter !== "all") {
       filtered = filtered.filter((booking) => normalizeStatus(booking.status) === statusFilter);
     }
+
+    filtered.sort((a, b) => {
+      const dateA = getScheduledDateTime(a);
+      const dateB = getScheduledDateTime(b);
+      return dateA.getTime() - dateB.getTime();
+    });
 
     setFilteredBookings(filtered);
   };
@@ -902,7 +962,7 @@ const AdminBookingManagement: React.FC = () => {
                         </div>
                         <div className="flex items-center gap-2 text-sm text-gray-600">
                           <Calendar className="h-4 w-4" />
-                          {formatDate(booking.scheduled_date)}
+                          {formatScheduledDateTime(booking)}
                         </div>
                       </div>
 

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -68,8 +68,8 @@ const VendorDashboard: React.FC = () => {
         return;
       }
 
-      // After upload, move directly to in_progress (processing)
-      const statusRes = await vendorAuthService.updateOrderStatus(orderId, "in_progress");
+      // After upload, mark pickup as complete (auto-transitions to in_progress)
+      const statusRes = await vendorAuthService.updateOrderStatus(orderId, "pickup_completed");
       if (!statusRes || !statusRes.success) {
         toast.error(statusRes.error || "Failed to update status");
         setUploadingFor(null);

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -297,10 +297,10 @@ const VendorDashboard: React.FC = () => {
                     <div className="font-medium text-sm md:text-base truncate">{order.name}</div>
                     <div className="text-sm text-gray-600 truncate">{order.phone}</div>
                     <div className="text-sm text-gray-500 mt-1">{order.service}</div>
-                    <div className="text-xs text-gray-500 mt-1">Pickup: {formatDateOnlyIST(order.scheduled_date)} {order.scheduled_time ? `at ${order.scheduled_time}` : ''}</div>
+                    <div className="text-xs text-gray-500 mt-1">Pickup: {formatScheduledDateTime(order)}</div>
                     {order.delivery_date && (
                       <div className="text-xs text-orange-600 mt-1 font-semibold">
-                        Delivery: {formatDateOnlyIST(order.delivery_date)} {order.delivery_time ? `at ${order.delivery_time}` : ''}
+                        Delivery: {formatScheduledDateTime({...order, scheduled_date: order.delivery_date, scheduled_time: order.delivery_time || '00:00'} as Order)}
                       </div>
                     )}
                     {order.address && (

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -199,9 +199,9 @@ const VendorDashboard: React.FC = () => {
                     <div className="font-medium text-sm md:text-base truncate">{order.name}</div>
                     <div className="text-sm text-gray-600 truncate">{order.phone}</div>
                     <div className="text-sm text-gray-500 mt-1">{order.service}</div>
-                    <div className="text-xs text-gray-500 mt-1">Pickup: {formatDateOnlyIST(order.scheduled_date)} {order.scheduled_time ? `at ${order.scheduled_time}` : ''}</div>
+                    <div className="text-xs text-gray-500 mt-1">Pickup: {formatScheduledDateTime(order)}</div>
                     {order.delivery_date && (
-                      <div className="text-xs text-gray-500">Delivery: {formatDateOnlyIST(order.delivery_date)} {order.delivery_time ? `at ${order.delivery_time}` : ''}</div>
+                      <div className="text-xs text-gray-500">Delivery: {formatScheduledDateTime({...order, scheduled_date: order.delivery_date, scheduled_time: order.delivery_time || '00:00'} as Order)}</div>
                     )}
                     {order.address && (
                       <div className="text-xs text-gray-600 mt-2 p-2 bg-gray-50 rounded">📍 {order.address}</div>

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -53,6 +53,7 @@ const formatScheduledDateTime = (order: Order): string => {
       timeZone: 'Asia/Kolkata',
       day: 'numeric',
       month: 'short',
+      year: 'numeric'
     });
 
     if (!timeStr || timeStr === '00:00') {
@@ -67,7 +68,7 @@ const formatScheduledDateTime = (order: Order): string => {
         hour12: true
       });
 
-    return `${dayMonth} at ${timeFormatted}`;
+    return `${dayMonth}, ${timeFormatted}`;
   } catch (e) {
     return formatDateOnlyIST(order.scheduled_date);
   }

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -23,6 +23,56 @@ interface Order {
   total_price?: number;
 }
 
+const getScheduledDateTime = (order: Order): Date => {
+  try {
+    const dateStr = order.scheduled_date || '';
+    const timeStr = order.scheduled_time || '00:00';
+
+    if (!dateStr) return new Date(0);
+
+    const [hours, minutes] = timeStr.split(':').map(Number);
+    const dateObj = new Date(dateStr);
+    dateObj.setHours(hours || 0, minutes || 0, 0, 0);
+    return dateObj;
+  } catch (e) {
+    return new Date(0);
+  }
+};
+
+const formatScheduledDateTime = (order: Order): string => {
+  try {
+    const dateStr = order.scheduled_date || '';
+    const timeStr = order.scheduled_time || '00:00';
+
+    if (!dateStr) return 'N/A';
+
+    const dateObj = new Date(dateStr);
+    const [hours, minutes] = timeStr.split(':').map(Number);
+
+    const dayMonth = dateObj.toLocaleString('en-IN', {
+      timeZone: 'Asia/Kolkata',
+      day: 'numeric',
+      month: 'short',
+    });
+
+    if (!timeStr || timeStr === '00:00') {
+      return dayMonth;
+    }
+
+    const timeFormatted = new Date(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate(), hours, minutes)
+      .toLocaleString('en-IN', {
+        timeZone: 'Asia/Kolkata',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      });
+
+    return `${dayMonth} at ${timeFormatted}`;
+  } catch (e) {
+    return formatDateOnlyIST(order.scheduled_date);
+  }
+};
+
 const VendorDashboard: React.FC = () => {
   const navigate = useNavigate();
   const [orders, setOrders] = useState<Order[]>([]);
@@ -105,9 +155,17 @@ const VendorDashboard: React.FC = () => {
     navigate("/vendor/login");
   };
 
-  const bucketA = orders.filter(o => o.status !== 'ready_for_delivery' && o.status !== 'delivered' && o.status !== 'completed' && o.status !== 'cancelled');
-  const bucketB = orders.filter(o => o.status === 'ready_for_delivery');
-  const completed = orders.filter(o => (o.status === 'completed' || o.status === 'delivered') && o.status !== 'cancelled');
+  const sortOrdersByTime = (ordersToSort: Order[]): Order[] => {
+    return [...ordersToSort].sort((a, b) => {
+      const dateA = getScheduledDateTime(a);
+      const dateB = getScheduledDateTime(b);
+      return dateA.getTime() - dateB.getTime();
+    });
+  };
+
+  const bucketA = sortOrdersByTime(orders.filter(o => o.status !== 'ready_for_delivery' && o.status !== 'delivered' && o.status !== 'completed' && o.status !== 'cancelled'));
+  const bucketB = sortOrdersByTime(orders.filter(o => o.status === 'ready_for_delivery'));
+  const completed = sortOrdersByTime(orders.filter(o => (o.status === 'completed' || o.status === 'delivered') && o.status !== 'cancelled'));
 
   if (loading && orders.length === 0) {
     return (

--- a/src/pages/vendor/VendorOrderDetails.tsx
+++ b/src/pages/vendor/VendorOrderDetails.tsx
@@ -171,17 +171,46 @@ const VendorOrderDetails: React.FC = () => {
                     <div className="border-t pt-6">
                         <h3 className="text-sm font-semibold text-gray-600 mb-4">Update Status</h3>
                         <div className="flex flex-wrap gap-3">
-                            {['pending', 'in_progress', 'completed', 'cancelled'].map((status) => (
+                            {order.status === 'vendor_assigned' && (
                                 <Button
-                                    key={status}
-                                    variant={order.status === status ? 'default' : 'outline'}
-                                    onClick={() => handleStatusUpdate(status)}
+                                    variant="default"
+                                    onClick={() => handleStatusUpdate('pickup_completed')}
                                     disabled={updating}
                                     className="capitalize"
                                 >
-                                    {status.replace('_', ' ')}
+                                    Mark Pickup Complete
                                 </Button>
-                            ))}
+                            )}
+                            {order.status === 'pickup_completed' && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => handleStatusUpdate('in_progress')}
+                                    disabled={updating}
+                                    className="capitalize"
+                                >
+                                    Mark In Progress
+                                </Button>
+                            )}
+                            {order.status === 'in_progress' && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => handleStatusUpdate('ready_for_delivery')}
+                                    disabled={updating}
+                                    className="capitalize"
+                                >
+                                    Mark Ready for Delivery
+                                </Button>
+                            )}
+                            {order.status === 'ready_for_delivery' && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => handleStatusUpdate('delivered')}
+                                    disabled={updating}
+                                    className="capitalize"
+                                >
+                                    Mark Delivered
+                                </Button>
+                            )}
                         </div>
                     </div>
                 </Card>

--- a/src/pages/vendor/VendorOrderDetails.tsx
+++ b/src/pages/vendor/VendorOrderDetails.tsx
@@ -181,16 +181,6 @@ const VendorOrderDetails: React.FC = () => {
                                     Mark Pickup Complete
                                 </Button>
                             )}
-                            {order.status === 'pickup_completed' && (
-                                <Button
-                                    variant="default"
-                                    onClick={() => handleStatusUpdate('in_progress')}
-                                    disabled={updating}
-                                    className="capitalize"
-                                >
-                                    Mark In Progress
-                                </Button>
-                            )}
                             {order.status === 'in_progress' && (
                                 <Button
                                     variant="default"


### PR DESCRIPTION
**Purpose**

The user wants to improve the admin and vendor experience by:
1. Displaying the assigned vendor in the admin booking list.
2. Automating the order status update to "in_progress" after a vendor completes a pickup.
3. Simplifying the status update interface for vendors.

**Code changes**

- **`backend/routes/vendor-orders.js`**: Automatically transitions the order status from `pickup_completed` to `in_progress`.
- **`src/components/AdminBookingManagement.tsx`**: Fixed the admin view to show the `assignedVendor` instead of `vendor`.
- **`src/pages/vendor/VendorOrderDetails.tsx`**: Replaced the generic status buttons with action-specific buttons like "Mark Pickup Complete" that appear based on the current order status.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4b4a36376eba48809806b3acd33579f5/pixel-space)

👀 [Preview Link](https://4b4a36376eba48809806b3acd33579f5-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4b4a36376eba48809806b3acd33579f5</projectId>-->
<!--<branchName>pixel-space</branchName>-->