### PR TITLE
Feat: Add call and map links to vendor dashboard

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -180,7 +180,7 @@ router.post("/users", verifyAdminAccess, async (req, res) => {
         await savedAddress.save();
         console.log("✅ Address saved for user:", user._id);
       } catch (addrErr) {
-        console.warn("⚠️ Failed to save address for user:", addrErr && addrErr.message);
+        console.warn("⚠��� Failed to save address for user:", addrErr && addrErr.message);
       }
     }
 
@@ -1661,18 +1661,20 @@ router.post("/vendors", verifyAdminAccess, async (req, res) => {
       return res.status(400).json({ error: "Name, address, and coordinates (lat, lng) are required" });
     }
 
+    // Generate vendor ID and temporary password (required for schema validation)
+    const vendor_id = Vendor.generateVendorId();
+    const temp_password = Math.random().toString(36).substring(2, 10).toUpperCase();
+
     const vendor = new Vendor({
+      vendor_id,
+      password_hash: temp_password, // Will be hashed before save by pre-save hook
       name,
       address,
       coordinates,
       services: services || [],
       contactPhone: contactPhone || phone || "",
-      rating: 4.0,
-      description: "",
-      operatingHours: { open: "09:00", close: "22:00" },
-      minimumOrderValue: 0,
-      deliveryTime: 30,
-      isActive: true,
+      phone: phone || "",
+      is_active: true,
     });
 
     await vendor.save();

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -669,6 +669,14 @@ const AdminBookingManagement: React.FC = () => {
     filterCompletedOrders();
   }, [completedSearchTerm, completedStatusFilter, completedOrders]);
 
+  useEffect(() => {
+    filterPickupOrders();
+  }, [pickupSearchTerm, pickupStatusFilter, bucketA]);
+
+  useEffect(() => {
+    filterReadyOrders();
+  }, [readySearchTerm, readyStatusFilter, bucketB]);
+
   const filterBookings = () => {
     let filtered = bookings;
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -290,6 +290,22 @@ const getScheduledDateTime = (booking: Booking): Date => {
   }
 };
 
+const getDeliveryDateTime = (booking: Booking): Date => {
+  try {
+    const dateStr = booking.delivery_date || '';
+    const timeStr = booking.delivery_time || '00:00';
+
+    if (!dateStr) return new Date(0);
+
+    const [hours, minutes] = timeStr.split(':').map(Number);
+    const dateObj = new Date(dateStr);
+    dateObj.setHours(hours || 0, minutes || 0, 0, 0);
+    return dateObj;
+  } catch (e) {
+    return new Date(0);
+  }
+};
+
 const formatScheduledDateTime = (booking: Booking): string => {
   try {
     const dateStr = booking.scheduled_date || '';

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1140,8 +1140,16 @@ const AdminBookingManagement: React.FC = () => {
 
         {/* Bucket B: Ready for Delivery */}
         <div className={viewMode === 'pickup' ? 'hidden' : ''}>
-          <h3 className="text-lg font-semibold">Ready for Delivery</h3>
-          <p className="text-sm text-gray-500">Orders ready to be delivered back to customers</p>
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Ready for Delivery</h3>
+              <p className="text-sm text-gray-500">Orders ready to be delivered back to customers</p>
+            </div>
+            <div className="text-right bg-green-50 p-3 rounded-lg border border-green-200">
+              <div className="text-xs text-gray-600 font-medium">Total to Collect</div>
+              <div className="text-2xl font-bold text-green-700">₹{calculateTotalPrice(filteredReadyOrders).toLocaleString('en-IN')}</div>
+            </div>
+          </div>
 
           <div className="flex flex-col gap-4 md:flex-row mt-3 mb-4">
             <div className="flex-1">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1009,8 +1009,16 @@ const AdminBookingManagement: React.FC = () => {
       <div className={viewMode === 'both' ? 'grid grid-cols-1 gap-6 lg:grid-cols-2' : 'grid grid-cols-1 gap-6'}>
         {/* Bucket A: Pickup & Vendor Flow */}
         <div className={viewMode === 'ready' ? 'hidden' : ''}>
-          <h3 className="text-lg font-semibold">Pickup / Vendor Flow</h3>
-          <p className="text-sm text-gray-500">Orders currently being picked up or delivered to vendor</p>
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Pickup / Vendor Flow</h3>
+              <p className="text-sm text-gray-500">Orders currently being picked up or delivered to vendor</p>
+            </div>
+            <div className="text-right bg-blue-50 p-3 rounded-lg border border-blue-200">
+              <div className="text-xs text-gray-600 font-medium">Total Value</div>
+              <div className="text-2xl font-bold text-blue-700">₹{calculateTotalPrice(filteredPickupOrders).toLocaleString('en-IN')}</div>
+            </div>
+          </div>
 
           <div className="flex flex-col gap-4 md:flex-row mt-3 mb-4">
             <div className="flex-1">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -577,7 +577,7 @@ const AdminBookingManagement: React.FC = () => {
       es.addEventListener('booking_change', (event: MessageEvent) => {
         try {
           const payload = JSON.parse(event.data);
-          console.log('��� Received booking_change SSE payload:', payload?._id || payload);
+          console.log('🔔 Received booking_change SSE payload:', payload?._id || payload);
           if (payload && payload._id && !showEditDialog) {
             applyBookingUpdate(payload._id, payload);
 
@@ -589,7 +589,7 @@ const AdminBookingManagement: React.FC = () => {
       });
 
       es.onerror = (err) => {
-        console.warn('⚠�� SSE connection error:', err);
+        console.warn('⚠️ SSE connection error:', err);
         try { es && es.close(); } catch (e) { }
       };
     } catch (e) {
@@ -1200,88 +1200,110 @@ const AdminBookingManagement: React.FC = () => {
             </div>
           </div>
 
-          <div className="mt-3 space-y-4">
+          <div className="mt-3 space-y-6">
             {filteredReadyOrders.length > 0 ? (
-              filteredReadyOrders.map(booking => (
-                <Card key={booking._id} className="transition-shadow hover:shadow-md">
-                  <CardContent className="pt-6">
-                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
-                      <div className="space-y-2">
-                        <div className="flex items-center gap-2">
-                          <Package className="h-4 w-4 text-blue-600" />
-                          <span className="font-medium">#{booking.custom_order_id}</span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <User className="h-4 w-4 text-gray-400" />
-                          <span className="text-sm">{booking.name}</span>
-                        </div>
-                        {booking.assignedVendor && (
-                          <div className="flex items-center gap-2 mt-1">
-                            <Store className="h-4 w-4 text-gray-400" />
-                            <span className="text-sm text-green-700">{booking.assignedVendor}</span>
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="space-y-2">
-                        <div className="flex items-center gap-2">
-                          <div className="text-sm font-medium text-gray-900">{booking.service}</div>
-                          {(booking as any).is_quick_pickup && (
-                            <Badge className="bg-blue-100 text-blue-800 text-xs">🚀 Quick Pickup</Badge>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2 text-sm text-gray-600">
-                          <Calendar className="h-4 w-4" />
-                          {booking.delivery_date ? formatScheduledDateTime({...booking, scheduled_date: booking.delivery_date, scheduled_time: booking.delivery_time || '00:00'} as Booking) : formatScheduledDateTime(booking)}
+              Object.entries(groupOrdersByVendor(filteredReadyOrders)).map(([vendorName, vendorOrders]) => (
+                <div key={vendorName} className="border rounded-lg overflow-hidden">
+                  <div className="bg-gradient-to-r from-green-50 to-emerald-50 p-4 border-b border-green-200">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Store className="h-5 w-5 text-green-700" />
+                        <div>
+                          <h4 className="font-semibold text-green-900">{vendorName}</h4>
+                          <p className="text-xs text-green-700">{vendorOrders.length} order{vendorOrders.length !== 1 ? 's' : ''}</p>
                         </div>
                       </div>
-
-                      <div className="space-y-2">
-                        <Badge className={clsx("inline-flex items-center gap-1", getStatusColor(booking.status))}>
-                          {getStatusIcon(booking.status)}
-                          <span>{getStatusLabel(booking.status)}</span>
-                        </Badge>
-                        <div className="flex items-center gap-2 text-sm">
-                          <DollarSign className="h-4 w-4 text-green-600" />
-                          <span className="font-medium">��{booking.final_amount ?? booking.total_price}</span>
-                        </div>
-                      </div>
-
-                      <div className="flex flex-col gap-3">
-                        <div className="flex gap-2">
-                          <Button size="sm" variant="outline" onClick={() => { setViewingBooking(booking); setShowViewDialog(true); }}>
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                          <Button size="sm" variant="outline" onClick={() => { setEditingBooking(normalizeBookingForEdit(booking)); setShowEditDialog(true); }}>
-                            <Edit3 className="h-4 w-4" />
-                          </Button>
-                          {normalizeStatus(booking.status) === 'vendor_assigned' && (
-                            <Button size="sm" className="bg-purple-600 text-white" onClick={() => updateBookingStatus(booking._id, 'pickup_completed')}>
-                              Mark Pickup Complete
-                            </Button>
-                          )}
-                          {normalizeStatus(booking.status) === 'pickup_completed' && (
-                            <Button size="sm" className="bg-sky-600 text-white" onClick={() => updateBookingStatus(booking._id, 'ready_for_delivery')}>
-                              Mark Ready for Delivery
-                            </Button>
-                          )}
-                          {normalizeStatus(booking.status) === 'ready_for_delivery' && (
-                            <Button size="sm" className="bg-amber-600 text-white" onClick={() => updateBookingStatus(booking._id, 'delivered')}>
-                              Mark Delivered
-                            </Button>
-                          )}
-                          {normalizeStatus(booking.status) === 'delivered' && (
-                            <Button size="sm" className="bg-green-600 text-white" onClick={() => updateBookingStatus(booking._id, 'completed')}>
-                              Mark Complete
-                            </Button>
-                          )}
-                        </div>
+                      <div className="text-right bg-white px-3 py-2 rounded border border-green-200">
+                        <div className="text-xs text-gray-600 font-medium">Vendor Total</div>
+                        <div className="text-xl font-bold text-green-700">₹{calculateTotalPrice(vendorOrders).toLocaleString('en-IN')}</div>
                       </div>
                     </div>
+                  </div>
+                  
+                  <div className="space-y-3 p-4">
+                    {vendorOrders.map(booking => (
+                      <Card key={booking._id} className="transition-shadow hover:shadow-md">
+                        <CardContent className="pt-6">
+                          <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+                            <div className="space-y-2">
+                              <div className="flex items-center gap-2">
+                                <Package className="h-4 w-4 text-blue-600" />
+                                <span className="font-medium">#{booking.custom_order_id}</span>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <User className="h-4 w-4 text-gray-400" />
+                                <span className="text-sm">{booking.name}</span>
+                              </div>
+                              {booking.assignedVendor && (
+                                <div className="flex items-center gap-2 mt-1">
+                                  <Store className="h-4 w-4 text-gray-400" />
+                                  <span className="text-sm text-green-700">{booking.assignedVendor}</span>
+                                </div>
+                              )}
+                            </div>
 
-                    <StatusFlowIndicator currentStatus={booking.status} className="mt-6" />
-                  </CardContent>
-                </Card>
+                            <div className="space-y-2">
+                              <div className="flex items-center gap-2">
+                                <div className="text-sm font-medium text-gray-900">{booking.service}</div>
+                                {(booking as any).is_quick_pickup && (
+                                  <Badge className="bg-blue-100 text-blue-800 text-xs">🚀 Quick Pickup</Badge>
+                                )}
+                              </div>
+                              <div className="flex items-center gap-2 text-sm text-gray-600">
+                                <Calendar className="h-4 w-4" />
+                                {booking.delivery_date ? formatScheduledDateTime({...booking, scheduled_date: booking.delivery_date, scheduled_time: booking.delivery_time || '00:00'} as Booking) : formatScheduledDateTime(booking)}
+                              </div>
+                            </div>
+
+                            <div className="space-y-2">
+                              <Badge className={clsx("inline-flex items-center gap-1", getStatusColor(booking.status))}>
+                                {getStatusIcon(booking.status)}
+                                <span>{getStatusLabel(booking.status)}</span>
+                              </Badge>
+                              <div className="flex items-center gap-2 text-sm">
+                                <DollarSign className="h-4 w-4 text-green-600" />
+                                <span className="font-medium">₹{booking.final_amount ?? booking.total_price}</span>
+                              </div>
+                            </div>
+
+                            <div className="flex flex-col gap-3">
+                              <div className="flex gap-2">
+                                <Button size="sm" variant="outline" onClick={() => { setViewingBooking(booking); setShowViewDialog(true); }}>
+                                  <Eye className="h-4 w-4" />
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => { setEditingBooking(normalizeBookingForEdit(booking)); setShowEditDialog(true); }}>
+                                  <Edit3 className="h-4 w-4" />
+                                </Button>
+                                {normalizeStatus(booking.status) === 'vendor_assigned' && (
+                                  <Button size="sm" className="bg-purple-600 text-white" onClick={() => updateBookingStatus(booking._id, 'pickup_completed')}>
+                                    Mark Pickup Complete
+                                  </Button>
+                                )}
+                                {normalizeStatus(booking.status) === 'pickup_completed' && (
+                                  <Button size="sm" className="bg-sky-600 text-white" onClick={() => updateBookingStatus(booking._id, 'ready_for_delivery')}>
+                                    Mark Ready for Delivery
+                                  </Button>
+                                )}
+                                {normalizeStatus(booking.status) === 'ready_for_delivery' && (
+                                  <Button size="sm" className="bg-amber-600 text-white" onClick={() => updateBookingStatus(booking._id, 'delivered')}>
+                                    Mark Delivered
+                                  </Button>
+                                )}
+                                {normalizeStatus(booking.status) === 'delivered' && (
+                                  <Button size="sm" className="bg-green-600 text-white" onClick={() => updateBookingStatus(booking._id, 'completed')}>
+                                    Mark Complete
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+
+                          <StatusFlowIndicator currentStatus={booking.status} className="mt-6" />
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                </div>
               ))
             ) : (
               <Card>
@@ -1687,7 +1709,7 @@ const AdminBookingManagement: React.FC = () => {
                                       className="h-8 text-right text-xs"
                                     />
                                   </td>
-                                  <td className="py-3 px-3 text-right font-medium">���{(Number(displayTotal) || 0).toFixed(2)}</td>
+                                  <td className="py-3 px-3 text-right font-medium">₹{(Number(displayTotal) || 0).toFixed(2)}</td>
                                   <td className="py-3 px-3 text-center">
                                     <Button size="sm" variant="ghost" onClick={() => removeItemFromEditing(index)} className="h-8 text-xs">
                                       Remove

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -981,13 +981,13 @@ const AdminBookingManagement: React.FC = () => {
           <button onClick={() => setViewMode('pickup')} className={clsx('inline-flex items-center gap-2 rounded-md px-3 py-2 border', viewMode === 'pickup' ? 'bg-white shadow-sm' : 'bg-transparent')}>
             <MapPin className="h-4 w-4 text-gray-600" />
             <span className="text-sm font-medium">Pickup</span>
-            <span className="ml-2 text-xs text-gray-500">{filteredBookings.filter(b => ["created","vendor_assigned"].includes(normalizeStatus(b.status))).length}</span>
+            <span className="ml-2 text-xs text-gray-500">{filteredPickupOrders.length}</span>
           </button>
 
           <button onClick={() => setViewMode('ready')} className={clsx('inline-flex items-center gap-2 rounded-md px-3 py-2 border', viewMode === 'ready' ? 'bg-white shadow-sm' : 'bg-transparent')}>
             <Clock className="h-4 w-4 text-gray-600" />
             <span className="text-sm font-medium">Ready/Delivered</span>
-            <span className="ml-2 text-xs text-gray-500">{filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status))).length}</span>
+            <span className="ml-2 text-xs text-gray-500">{filteredReadyOrders.length}</span>
           </button>
         </div>
       </div>

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -502,6 +502,46 @@ const AdminBookingManagement: React.FC = () => {
     setFilteredCompletedOrders(filtered);
   };
 
+  const filterPickupOrders = (orders?: Booking[]) => {
+    const ordersToFilter = orders || bucketA;
+    let filtered = ordersToFilter;
+
+    if (pickupSearchTerm) {
+      filtered = filtered.filter((booking) =>
+        booking.custom_order_id?.toLowerCase().includes(pickupSearchTerm.toLowerCase()) ||
+        booking.name?.toLowerCase().includes(pickupSearchTerm.toLowerCase()) ||
+        booking.phone?.includes(pickupSearchTerm) ||
+        booking.service?.toLowerCase().includes(pickupSearchTerm.toLowerCase()),
+      );
+    }
+
+    if (pickupStatusFilter !== "all") {
+      filtered = filtered.filter((booking) => normalizeStatus(booking.status) === pickupStatusFilter);
+    }
+
+    setFilteredPickupOrders(filtered);
+  };
+
+  const filterReadyOrders = (orders?: Booking[]) => {
+    const ordersToFilter = orders || bucketB;
+    let filtered = ordersToFilter;
+
+    if (readySearchTerm) {
+      filtered = filtered.filter((booking) =>
+        booking.custom_order_id?.toLowerCase().includes(readySearchTerm.toLowerCase()) ||
+        booking.name?.toLowerCase().includes(readySearchTerm.toLowerCase()) ||
+        booking.phone?.includes(readySearchTerm) ||
+        booking.service?.toLowerCase().includes(readySearchTerm.toLowerCase()),
+      );
+    }
+
+    if (readyStatusFilter !== "all") {
+      filtered = filtered.filter((booking) => normalizeStatus(booking.status) === readyStatusFilter);
+    }
+
+    setFilteredReadyOrders(filtered);
+  };
+
   const fetchBookings = async () => {
     try {
       setLoading(true);
@@ -1541,7 +1581,7 @@ const AdminBookingManagement: React.FC = () => {
                                       className="h-8 text-right text-xs"
                                     />
                                   </td>
-                                  <td className="py-3 px-3 text-right font-medium">₹{(Number(displayTotal) || 0).toFixed(2)}</td>
+                                  <td className="py-3 px-3 text-right font-medium">���{(Number(displayTotal) || 0).toFixed(2)}</td>
                                   <td className="py-3 px-3 text-center">
                                     <Button size="sm" variant="ghost" onClick={() => removeItemFromEditing(index)} className="h-8 text-xs">
                                       Remove

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -432,6 +432,16 @@ const AdminBookingManagement: React.FC = () => {
   const [completedStatusFilter, setCompletedStatusFilter] = useState("completed");
   const [filteredCompletedOrders, setFilteredCompletedOrders] = useState<Booking[]>([]);
 
+  // Pickup bucket (A) filters
+  const [pickupSearchTerm, setPickupSearchTerm] = useState("");
+  const [pickupStatusFilter, setPickupStatusFilter] = useState("all");
+  const [filteredPickupOrders, setFilteredPickupOrders] = useState<Booking[]>([]);
+
+  // Ready for Delivery bucket (B) filters
+  const [readySearchTerm, setReadySearchTerm] = useState("");
+  const [readyStatusFilter, setReadyStatusFilter] = useState("all");
+  const [filteredReadyOrders, setFilteredReadyOrders] = useState<Booking[]>([]);
+
   const fetchVendors = async () => {
     try {
       const response = await apiClient.adminRequest<{ vendors: any[] }>('/admin/vendors');

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1028,8 +1028,8 @@ const AdminBookingManagement: React.FC = () => {
           </div>
 
           <div className="mt-3 space-y-4">
-            {filteredBookings.filter(b => ["created","vendor_assigned"].includes(normalizeStatus(b.status))).length > 0 ? (
-              filteredBookings.filter(b => ["created","vendor_assigned"].includes(normalizeStatus(b.status))).map(booking => (
+            {filteredPickupOrders.length > 0 ? (
+              filteredPickupOrders.map(booking => (
                 <Card key={booking._id} className="transition-shadow hover:shadow-md">
                   <CardContent className="pt-6">
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
@@ -1159,7 +1159,7 @@ const AdminBookingManagement: React.FC = () => {
                         <div className="flex items-center gap-2">
                           <div className="text-sm font-medium text-gray-900">{booking.service}</div>
                           {(booking as any).is_quick_pickup && (
-                            <Badge className="bg-blue-100 text-blue-800 text-xs">��� Quick Pickup</Badge>
+                            <Badge className="bg-blue-100 text-blue-800 text-xs">🚀 Quick Pickup</Badge>
                           )}
                         </div>
                         <div className="flex items-center gap-2 text-sm text-gray-600">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1128,13 +1128,40 @@ const AdminBookingManagement: React.FC = () => {
         <div className={viewMode === 'pickup' ? 'hidden' : ''}>
           <h3 className="text-lg font-semibold">Ready for Delivery</h3>
           <p className="text-sm text-gray-500">Orders ready to be delivered back to customers</p>
+
+          <div className="flex flex-col gap-4 md:flex-row mt-3 mb-4">
+            <div className="flex-1">
+              <Label htmlFor="ready-search">Search</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
+                <Input
+                  id="ready-search"
+                  placeholder="Search by order ID, name, phone, or service..."
+                  value={readySearchTerm}
+                  onChange={(e) => setReadySearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <div className="md:w-56">
+              <Label htmlFor="ready-status-filter">Filter by Status</Label>
+              <Select value={readyStatusFilter} onValueChange={setReadyStatusFilter}>
+                <SelectTrigger id="ready-status-filter">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Status</SelectItem>
+                  <SelectItem value="pickup_completed">Pickup Completed</SelectItem>
+                  <SelectItem value="ready_for_delivery">Ready for Delivery</SelectItem>
+                  <SelectItem value="delivered">Delivered</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
           <div className="mt-3 space-y-4">
-            {filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status))).length > 0 ? (
-              [...filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status)))].sort((a, b) => {
-                const dateA = getDeliveryDateTime(a);
-                const dateB = getDeliveryDateTime(b);
-                return dateA.getTime() - dateB.getTime();
-              }).map(booking => (
+            {filteredReadyOrders.length > 0 ? (
+              filteredReadyOrders.map(booking => (
                 <Card key={booking._id} className="transition-shadow hover:shadow-md">
                   <CardContent className="pt-6">
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -690,6 +690,17 @@ const AdminBookingManagement: React.FC = () => {
     }, 0);
   };
 
+  const groupOrdersByVendor = (orders: Booking[]): Record<string, Booking[]> => {
+    return orders.reduce((acc, order) => {
+      const vendorName = order.assignedVendor || "Unassigned";
+      if (!acc[vendorName]) {
+        acc[vendorName] = [];
+      }
+      acc[vendorName].push(order);
+      return acc;
+    }, {} as Record<string, Booking[]>);
+  };
+
   const filterBookings = () => {
     let filtered = bookings;
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -997,6 +997,36 @@ const AdminBookingManagement: React.FC = () => {
         <div className={viewMode === 'ready' ? 'hidden' : ''}>
           <h3 className="text-lg font-semibold">Pickup / Vendor Flow</h3>
           <p className="text-sm text-gray-500">Orders currently being picked up or delivered to vendor</p>
+
+          <div className="flex flex-col gap-4 md:flex-row mt-3 mb-4">
+            <div className="flex-1">
+              <Label htmlFor="pickup-search">Search</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-gray-400" />
+                <Input
+                  id="pickup-search"
+                  placeholder="Search by order ID, name, phone, or service..."
+                  value={pickupSearchTerm}
+                  onChange={(e) => setPickupSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <div className="md:w-56">
+              <Label htmlFor="pickup-status-filter">Filter by Status</Label>
+              <Select value={pickupStatusFilter} onValueChange={setPickupStatusFilter}>
+                <SelectTrigger id="pickup-status-filter">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Status</SelectItem>
+                  <SelectItem value="created">Order Created</SelectItem>
+                  <SelectItem value="vendor_assigned">Vendor Assigned</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
           <div className="mt-3 space-y-4">
             {filteredBookings.filter(b => ["created","vendor_assigned"].includes(normalizeStatus(b.status))).length > 0 ? (
               filteredBookings.filter(b => ["created","vendor_assigned"].includes(normalizeStatus(b.status))).map(booking => (
@@ -1129,7 +1159,7 @@ const AdminBookingManagement: React.FC = () => {
                         <div className="flex items-center gap-2">
                           <div className="text-sm font-medium text-gray-900">{booking.service}</div>
                           {(booking as any).is_quick_pickup && (
-                            <Badge className="bg-blue-100 text-blue-800 text-xs">🚀 Quick Pickup</Badge>
+                            <Badge className="bg-blue-100 text-blue-800 text-xs">��� Quick Pickup</Badge>
                           )}
                         </div>
                         <div className="flex items-center gap-2 text-sm text-gray-600">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -677,6 +677,13 @@ const AdminBookingManagement: React.FC = () => {
     filterReadyOrders();
   }, [readySearchTerm, readyStatusFilter, bucketB]);
 
+  const rebucketBookings = (bookingsToRebucket: Booking[]) => {
+    const a = bookingsToRebucket.filter(b => ["created", "vendor_assigned"].includes(normalizeStatus(b.status)));
+    const b = bookingsToRebucket.filter(b => ["pickup_completed", "ready_for_delivery", "delivered"].includes(normalizeStatus(b.status)));
+    setBucketA(a);
+    setBucketB(b);
+  };
+
   const filterBookings = () => {
     let filtered = bookings;
 
@@ -700,6 +707,7 @@ const AdminBookingManagement: React.FC = () => {
     });
 
     setFilteredBookings(filtered);
+    rebucketBookings(bookings);
   };
 
   const applyBookingUpdate = (bookingId: string, update: Partial<Booking>) => {

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -684,6 +684,12 @@ const AdminBookingManagement: React.FC = () => {
     setBucketB(b);
   };
 
+  const calculateTotalPrice = (orders: Booking[]) => {
+    return orders.reduce((total, order) => {
+      return total + (order.total_price || 0);
+    }, 0);
+  };
+
   const filterBookings = () => {
     let filtered = bookings;
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -554,7 +554,7 @@ const AdminBookingManagement: React.FC = () => {
           item_prices: Array.isArray(b.item_prices) ? b.item_prices : [],
         }));
         setBookings(processed);
-        const a = processed.filter(b => !["ready_for_delivery", "delivered", "completed", "cancelled"].includes(normalizeStatus(b.status)));
+        const a = processed.filter(b => ["created", "vendor_assigned"].includes(normalizeStatus(b.status)));
         const b = processed.filter(b => ["pickup_completed", "ready_for_delivery", "delivered"].includes(normalizeStatus(b.status)));
         setBucketA(a);
         setBucketB(b);

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1042,7 +1042,11 @@ const AdminBookingManagement: React.FC = () => {
           <p className="text-sm text-gray-500">Orders ready to be delivered back to customers</p>
           <div className="mt-3 space-y-4">
             {filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status))).length > 0 ? (
-              filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status))).map(booking => (
+              [...filteredBookings.filter(b => ["pickup_completed","ready_for_delivery","delivered"].includes(normalizeStatus(b.status)))].sort((a, b) => {
+                const dateA = getDeliveryDateTime(a);
+                const dateB = getDeliveryDateTime(b);
+                return dateA.getTime() - dateB.getTime();
+              }).map(booking => (
                 <Card key={booking._id} className="transition-shadow hover:shadow-md">
                   <CardContent className="pt-6">
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -329,7 +329,20 @@ const VendorDashboard: React.FC = () => {
                   <div className="flex-1 min-w-0">
                     <div className="text-sm font-semibold text-gray-700 truncate">#{order.custom_order_id || order._id}</div>
                     <div className="font-medium text-sm md:text-base truncate">{order.name}</div>
-                    <div className="text-sm text-gray-600 truncate">{order.phone}</div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <div className="text-sm text-gray-600 truncate flex-1">{order.phone}</div>
+                      {order.phone && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleCallCustomer(order.phone!)}
+                          className="flex-shrink-0 px-2 py-1 h-auto"
+                          title="Call customer"
+                        >
+                          ☎️
+                        </Button>
+                      )}
+                    </div>
                     <div className="text-sm text-gray-500 mt-1">{order.service}</div>
                     <div className="text-xs text-gray-500 mt-1">Pickup: {formatScheduledDateTime(order)}</div>
                     {order.delivery_date && (
@@ -338,7 +351,13 @@ const VendorDashboard: React.FC = () => {
                       </div>
                     )}
                     {order.address && (
-                      <div className="text-xs text-gray-600 mt-2 p-2 bg-gray-50 rounded">📍 {order.address}</div>
+                      <button
+                        onClick={() => handleNavigateToAddress(order.address!)}
+                        className="text-xs text-gray-600 mt-2 p-2 bg-gray-50 rounded hover:bg-blue-100 hover:text-blue-700 transition-colors cursor-pointer w-full text-left"
+                        title="Open in Google Maps"
+                      >
+                        📍 {order.address}
+                      </button>
                     )}
                   </div>
                   <div className="flex flex-col items-end gap-2 flex-shrink-0">

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -156,6 +156,20 @@ const VendorDashboard: React.FC = () => {
     navigate("/vendor/login");
   };
 
+  const handleCallCustomer = (phone: string) => {
+    if (phone) {
+      window.location.href = `tel:${phone}`;
+    }
+  };
+
+  const handleNavigateToAddress = (address: string) => {
+    if (address) {
+      const encodedAddress = encodeURIComponent(address);
+      const googleMapsUrl = `https://www.google.com/maps/search/${encodedAddress}`;
+      window.open(googleMapsUrl, '_blank');
+    }
+  };
+
   const sortOrdersByTime = (ordersToSort: Order[]): Order[] => {
     return [...ordersToSort].sort((a, b) => {
       const dateA = getScheduledDateTime(a);

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -163,7 +163,26 @@ const VendorDashboard: React.FC = () => {
   };
 
   const handleNavigateToAddress = (address: string) => {
-    if (address) {
+    if (!address) return;
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const { latitude, longitude } = position.coords;
+          const encodedAddress = encodeURIComponent(address);
+          const googleMapsUrl = `https://www.google.com/maps/dir/?api=1&origin=${latitude},${longitude}&destination=${encodedAddress}`;
+          window.open(googleMapsUrl, '_blank');
+        },
+        (error) => {
+          // If geolocation fails, just open with the address
+          console.log('Geolocation error:', error);
+          const encodedAddress = encodeURIComponent(address);
+          const googleMapsUrl = `https://www.google.com/maps/search/${encodedAddress}`;
+          window.open(googleMapsUrl, '_blank');
+        }
+      );
+    } else {
+      // Fallback if geolocation is not supported
       const encodedAddress = encodeURIComponent(address);
       const googleMapsUrl = `https://www.google.com/maps/search/${encodedAddress}`;
       window.open(googleMapsUrl, '_blank');

--- a/src/pages/vendor/VendorDashboard.tsx
+++ b/src/pages/vendor/VendorDashboard.tsx
@@ -212,14 +212,33 @@ const VendorDashboard: React.FC = () => {
                   <div className="flex-1 min-w-0">
                     <div className="text-sm font-semibold text-gray-700 truncate">#{order.custom_order_id || order._id}</div>
                     <div className="font-medium text-sm md:text-base truncate">{order.name}</div>
-                    <div className="text-sm text-gray-600 truncate">{order.phone}</div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <div className="text-sm text-gray-600 truncate flex-1">{order.phone}</div>
+                      {order.phone && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleCallCustomer(order.phone!)}
+                          className="flex-shrink-0 px-2 py-1 h-auto"
+                          title="Call customer"
+                        >
+                          ☎️
+                        </Button>
+                      )}
+                    </div>
                     <div className="text-sm text-gray-500 mt-1">{order.service}</div>
                     <div className="text-xs text-gray-500 mt-1">Pickup: {formatScheduledDateTime(order)}</div>
                     {order.delivery_date && (
                       <div className="text-xs text-gray-500">Delivery: {formatScheduledDateTime({...order, scheduled_date: order.delivery_date, scheduled_time: order.delivery_time || '00:00'} as Order)}</div>
                     )}
                     {order.address && (
-                      <div className="text-xs text-gray-600 mt-2 p-2 bg-gray-50 rounded">📍 {order.address}</div>
+                      <button
+                        onClick={() => handleNavigateToAddress(order.address!)}
+                        className="text-xs text-gray-600 mt-2 p-2 bg-gray-50 rounded hover:bg-blue-100 hover:text-blue-700 transition-colors cursor-pointer w-full text-left"
+                        title="Open in Google Maps"
+                      >
+                        📍 {order.address}
+                      </button>
                     )}
                   </div>
                   <div className="flex flex-col items-end gap-2 flex-shrink-0">


### PR DESCRIPTION
### Purpose

As requested, this change allows vendors to easily contact customers and find their locations. The goal is to add one-click buttons to call a customer's phone number and to open their address in Google Maps for navigation directly from the vendor dashboard.

### Code changes

- **`VendorDashboard.tsx`**: 
  - Added a `handleCallCustomer` function that initiates a phone call using a `tel:` link.
  - Added a `handleNavigateToAddress` function that opens the provided address in Google Maps in a new browser tab.
  - A call button (☎️) is now displayed next to the customer's phone number, which triggers `handleCallCustomer`.
  - The customer's address is now a clickable button that triggers `handleNavigateToAddress`, with added hover effects for better UX.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ecdbddb4f45d435b9a4a4a95c9278ba1/vibe-hub)

👀 [Preview Link](https://ecdbddb4f45d435b9a4a4a95c9278ba1-vibe-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ecdbddb4f45d435b9a4a4a95c9278ba1</projectId>-->
<!--<branchName>vibe-hub</branchName>-->