### PR TITLE
feat: Allow users to pay for bookings with wallet balance

### DIFF
--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -246,6 +246,15 @@ const bookingSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    wallet_discount_amount: {
+      type: Number,
+      default: 0,
+      min: [0, "Wallet discount amount must be non-negative"],
+    },
+    wallet_discount_processed: {
+      type: Boolean,
+      default: false,
+    },
     charges_breakdown: {
       base_price: {
         type: Number,

--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -237,6 +237,15 @@ const bookingSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    wallet_applied_amount: {
+      type: Number,
+      default: 0,
+      min: [0, "Wallet applied amount must be non-negative"],
+    },
+    wallet_payment_processed: {
+      type: Boolean,
+      default: false,
+    },
     charges_breakdown: {
       base_price: {
         type: Number,

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -305,7 +305,59 @@ router.put("/bookings/:bookingId", verifyAdminAccess, async (req, res) => {
     console.log("✅ Updated timestamp:", booking.updated_at);
     console.log(`✅ Final booking state: total_price=${booking.total_price}, final_amount=${booking.final_amount}, item_prices count=${booking.item_prices?.length || 0}`);
 
-    // Auto-credit cashback to user wallet when order is completed
+    // Handle Wallet Discount Type 2: Deduct from wallet when admin applies wallet_discount_amount
+    if (updateData.wallet_discount_amount && updateData.wallet_discount_amount > 0 && booking.customer_id) {
+      try {
+        const customer = await User.findById(booking.customer_id);
+        if (customer && !booking.wallet_discount_processed) {
+          if (!customer.wallet) {
+            customer.wallet = { balance: 0, total_earned: 0, total_used: 0 };
+          }
+          if (!customer.wallet_transactions) {
+            customer.wallet_transactions = [];
+          }
+
+          const currentBalance = customer.wallet.balance || 0;
+          const walletDeductAmount = Math.min(updateData.wallet_discount_amount, currentBalance);
+
+          if (walletDeductAmount > 0) {
+            const newBalance = currentBalance - walletDeductAmount;
+
+            const transaction = {
+              _id: new mongoose.Types.ObjectId(),
+              type: "debit",
+              amount: walletDeductAmount,
+              source: "order_use",
+              booking_id: booking._id,
+              description: `Wallet payment for order ${booking.custom_order_id || booking._id}`,
+              balance_after: newBalance,
+              created_at: new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Kolkata" })),
+            };
+
+            customer.wallet.balance = newBalance;
+            customer.wallet.total_used = (customer.wallet.total_used || 0) + walletDeductAmount;
+            customer.wallet.last_transaction_at = transaction.created_at;
+            customer.wallet_transactions.push(transaction);
+
+            booking.wallet_discount_amount = walletDeductAmount;
+            booking.wallet_discount_processed = true;
+
+            await customer.save();
+            await booking.save();
+
+            console.log(`✅ Wallet deducted: ₹${walletDeductAmount} from user ${booking.customer_id}`);
+            console.log(`📊 Customer new wallet balance: ₹${newBalance}`);
+          } else {
+            console.warn(`⚠️ Insufficient wallet balance for deduction. Available: ₹${currentBalance}`);
+          }
+        }
+      } catch (walletError) {
+        console.error("⚠️ Failed to deduct wallet:", walletError);
+        // Don't fail the entire request if wallet deduction fails
+      }
+    }
+
+    // Auto-credit cashback to user wallet when order is completed (Type 1: Order Reward)
     if (updateData.status === "completed" && booking.customer_id && booking.cashback_amount > 0) {
       try {
         const customer = await User.findById(booking.customer_id);

--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -602,6 +602,70 @@ router.post("/", async (req, res) => {
     );
     console.log("🆔 Generated custom order ID:", booking.custom_order_id);
 
+    // Handle wallet balance deduction if user applied wallet amount
+    if (wallet_applied_amount && wallet_applied_amount > 0) {
+      try {
+        console.log(`💳 Processing wallet deduction: ₹${wallet_applied_amount}`);
+
+        // Refresh customer to get latest wallet data
+        const updatedCustomer = await User.findById(customer._id);
+
+        if (!updatedCustomer) {
+          console.error("❌ Customer not found for wallet deduction");
+        } else if (!updatedCustomer.wallet) {
+          console.error("❌ Customer wallet not initialized");
+        } else {
+          const currentBalance = updatedCustomer.wallet.balance || 0;
+
+          if (currentBalance < wallet_applied_amount) {
+            console.warn(`⚠️ Insufficient wallet balance. Available: ₹${currentBalance}, Requested: ₹${wallet_applied_amount}`);
+          } else {
+            // Deduct from wallet balance
+            updatedCustomer.wallet.balance = Math.max(0, currentBalance - wallet_applied_amount);
+            updatedCustomer.wallet.total_used = (updatedCustomer.wallet.total_used || 0) + wallet_applied_amount;
+            updatedCustomer.wallet.last_transaction_at = new Date();
+
+            // Add transaction record
+            if (!updatedCustomer.wallet_transactions) {
+              updatedCustomer.wallet_transactions = [];
+            }
+
+            const transaction = {
+              _id: new mongoose.Types.ObjectId(),
+              type: "debit",
+              amount: wallet_applied_amount,
+              source: "order_use",
+              booking_id: booking._id,
+              description: `Wallet payment for order ${booking.custom_order_id || booking._id}`,
+              balance_after: updatedCustomer.wallet.balance,
+              created_at: new Date(),
+            };
+
+            updatedCustomer.wallet_transactions.push(transaction);
+
+            // Save updated customer with wallet changes
+            await updatedCustomer.save();
+
+            console.log(`✅ Wallet deducted successfully. New balance: ₹${updatedCustomer.wallet.balance}`);
+            console.log(`📊 Transaction record created:`, {
+              amount: wallet_applied_amount,
+              booking_id: booking._id,
+              new_balance: updatedCustomer.wallet.balance,
+            });
+
+            // Update booking with wallet amount used
+            booking.wallet_applied_amount = wallet_applied_amount;
+            booking.wallet_payment_processed = true;
+            await booking.save();
+          }
+        }
+      } catch (walletError) {
+        console.error("❌ Error processing wallet deduction:", walletError);
+        // Log the error but don't fail the booking creation
+        // The booking is already created and confirmed
+      }
+    }
+
     // Check if this customer is using a referral discount
     try {
       console.log("🔍 Checking for referral discounts...");
@@ -1857,7 +1921,7 @@ router.put("/:bookingId/cancel", async (req, res) => {
       // More permissive fallback - if no userId provided, allow cancellation
       // This handles cases where the frontend doesn't send the user ID correctly
       if (!userId) {
-        console.log("⚠️ No user ID provided - allowing cancellation");
+        console.log("⚠��� No user ID provided - allowing cancellation");
         canCancel = true;
       } else {
         return res.status(403).json({

--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -64,6 +64,7 @@ router.post("/", async (req, res) => {
       special_instructions,
       charges_breakdown,
       item_prices: requestItemPrices,
+      wallet_applied_amount,
     } = req.body;
 
     // Validation

--- a/backend/routes/wallet.js
+++ b/backend/routes/wallet.js
@@ -12,13 +12,19 @@ const verifyUserToken = (req, res, next) => {
   try {
     const token = req.headers.authorization?.replace("Bearer ", "");
     if (!token) {
+      console.warn("❌ No token provided in Authorization header");
       return res.status(401).json({ error: "No token provided" });
     }
     const decoded = jwt.verify(token, JWT_SECRET);
-    req.user_id = decoded.user_id || decoded._id;
+    // Handle different token formats: userId, user_id, _id
+    req.user_id = decoded.userId || decoded.user_id || decoded._id;
+    if (!req.user_id) {
+      console.warn("❌ No user ID found in token payload:", Object.keys(decoded));
+      return res.status(401).json({ error: "Invalid token payload" });
+    }
     next();
   } catch (error) {
-    console.error("❌ Token verification error:", error);
+    console.error("❌ Token verification error:", error.message);
     res.status(401).json({ error: "Invalid or expired token" });
   }
 };

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -620,7 +620,7 @@ const AdminBookingManagement: React.FC = () => {
       es.addEventListener('booking_change', (event: MessageEvent) => {
         try {
           const payload = JSON.parse(event.data);
-          console.log('🔔 Received booking_change SSE payload:', payload?._id || payload);
+          console.log('�� Received booking_change SSE payload:', payload?._id || payload);
           if (payload && payload._id && !showEditDialog) {
             applyBookingUpdate(payload._id, payload);
 
@@ -2056,13 +2056,18 @@ const AdminBookingManagement: React.FC = () => {
                     <span className="text-sm text-gray-500">(Applied after cashback)</span>
                   </div>
 
-                  <div className="flex justify-between text-blue-600">
-                    <span>After Cashback:</span>
-                    <span>- ₹{computeEditingTotals(editingBooking).afterCashback.toFixed(2)}</span>
+                  <div className="flex justify-between text-green-600">
+                    <span>After Order Cashback (Type 1):</span>
+                    <span>₹{computeEditingTotals(editingBooking).afterCashback.toFixed(2)}</span>
                   </div>
 
                   <div className="flex justify-between text-blue-600">
-                    <span>Discount Amount:</span>
+                    <span>After Wallet Deduction (Type 2):</span>
+                    <span>₹{computeEditingTotals(editingBooking).afterWalletDiscount.toFixed(2)}</span>
+                  </div>
+
+                  <div className="flex justify-between text-orange-600">
+                    <span>Discount Amount (%):</span>
                     <span>- ₹{computeEditingTotals(editingBooking).discountAmount.toFixed(2)}</span>
                   </div>
 

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1048,7 +1048,7 @@ const AdminBookingManagement: React.FC = () => {
   };
 
   const computeEditingTotals = (bookingData: Booking | null) => {
-    if (!bookingData) return { total: 0, afterCashback: 0, discountAmount: 0, final: 0, cashbackAmount: 0 };
+    if (!bookingData) return { total: 0, afterCashback: 0, afterWalletDiscount: 0, discountAmount: 0, final: 0, cashbackAmount: 0, walletDiscountAmount: 0 };
     const items = bookingData.item_prices || [];
     const subtotal = items.reduce((s, it) => {
       const qty = Number(it.quantity ?? 0) || 0;
@@ -1057,17 +1057,25 @@ const AdminBookingManagement: React.FC = () => {
       return s + itemTotal;
     }, 0);
 
+    // Cashback Type 1: Order cashback (credited when order completes)
     const cashbackAmount = Number((bookingData as any).cashback_amount ?? 0) || 0;
     const afterCashback = Math.max(0, subtotal - cashbackAmount);
 
-    const discountPercent = Number(bookingData.discount_percent ?? 0) || 0;
-    const discountAmount = +(afterCashback * (discountPercent / 100));
+    // Cashback Type 2: Wallet discount (deducted from wallet immediately)
+    const walletDiscountAmount = Number((bookingData as any).wallet_discount_amount ?? 0) || 0;
+    const afterWalletDiscount = Math.max(0, afterCashback - walletDiscountAmount);
 
-    const finalAmount = afterCashback - discountAmount;
+    // Percentage discount
+    const discountPercent = Number(bookingData.discount_percent ?? 0) || 0;
+    const discountAmount = +(afterWalletDiscount * (discountPercent / 100));
+
+    const finalAmount = afterWalletDiscount - discountAmount;
     return {
       total: +subtotal.toFixed(2),
       cashbackAmount: +cashbackAmount.toFixed(2),
       afterCashback: +afterCashback.toFixed(2),
+      walletDiscountAmount: +walletDiscountAmount.toFixed(2),
+      afterWalletDiscount: +afterWalletDiscount.toFixed(2),
       discountAmount: +discountAmount.toFixed(2),
       final: +finalAmount.toFixed(2),
     };

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1953,48 +1953,76 @@ const AdminBookingManagement: React.FC = () => {
                   </div>
                 </div>
 
-                {/* Customer Wallet Balance */}
-                {editingBooking?.customer_id && (
-                  <div className="mb-4 rounded-lg bg-blue-50 border border-blue-200 p-4">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1">
-                        <label className="block text-sm font-semibold text-gray-900 mb-2">
-                          👛 Customer Wallet Balance
-                        </label>
-                        <p className="text-xs text-gray-600 mb-3">
-                          View and manage customer's available wallet credits
+                {/* Two-Tier Cashback System */}
+                <div className="mb-4 rounded-lg bg-purple-50 border border-purple-200 p-4">
+                  <div className="mb-4">
+                    <label className="block text-sm font-semibold text-gray-900 mb-2">
+                      💳 Type 1: Order Cashback (Auto-credited on completion)
+                    </label>
+                    <p className="text-xs text-gray-600 mb-2">
+                      Amount automatically credited to customer's wallet when order is marked complete
+                    </p>
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        placeholder="e.g., 50"
+                        value={String((editingBooking as any)?.cashback_amount ?? 0)}
+                        onChange={(e) => {
+                          const val = parseFloat(e.target.value || "0") || 0;
+                          setEditingBooking((prev) => prev ? ({ ...prev, cashback_amount: val } as Booking) : prev);
+                        }}
+                        className="flex-1"
+                      />
+                      <div className="text-right">
+                        <p className="text-sm font-bold text-purple-600">
+                          ₹{((editingBooking as any)?.cashback_amount ?? 0).toFixed(2)}
                         </p>
-                        <div className="grid grid-cols-2 gap-3 mb-3">
-                          <div className="bg-white rounded p-2">
-                            <p className="text-xs text-gray-600">Current Balance</p>
-                            <p className="text-lg font-bold text-blue-600">
-                              ₹{((editingBooking as any)?.customer_wallet_balance ?? 0).toFixed(2)}
-                            </p>
-                          </div>
-                          <div className="bg-white rounded p-2">
-                            <p className="text-xs text-gray-600">Total Earned</p>
-                            <p className="text-lg font-bold text-green-600">
-                              ₹{((editingBooking as any)?.customer_total_earned ?? 0).toFixed(2)}
-                            </p>
-                          </div>
-                        </div>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="w-full text-xs"
-                          onClick={() => {
-                            const customerId = (editingBooking as any)?.customer_id?._id || (editingBooking as any)?.customer_id;
-                            if (customerId) {
-                              window.open(`/wallet?customer=${customerId}`, '_blank');
-                            }
-                          }}
-                        >
-                          View Full Wallet History
-                        </Button>
                       </div>
                     </div>
                   </div>
-                )}
+
+                  <Separator className="my-3" />
+
+                  <div>
+                    <label className="block text-sm font-semibold text-gray-900 mb-2">
+                      👛 Type 2: Wallet Deduction (Debit wallet to reduce order amount)
+                    </label>
+                    <p className="text-xs text-gray-600 mb-2">
+                      Deduct from customer's wallet balance to reduce order amount. Wallet is debited immediately.
+                    </p>
+                    {editingBooking?.customer_id && (
+                      <div className="bg-white rounded p-2 mb-3 border border-purple-200">
+                        <p className="text-xs text-gray-600">Available Wallet Balance:</p>
+                        <p className="text-xl font-bold text-blue-600">
+                          ₹{((editingBooking as any)?.customer_wallet_balance ?? 0).toFixed(2)}
+                        </p>
+                      </div>
+                    )}
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={(editingBooking as any)?.customer_wallet_balance ?? 0}
+                        step="0.01"
+                        placeholder="e.g., 30"
+                        value={String((editingBooking as any)?.wallet_discount_amount ?? 0)}
+                        onChange={(e) => {
+                          const val = parseFloat(e.target.value || "0") || 0;
+                          const maxWallet = (editingBooking as any)?.customer_wallet_balance ?? 0;
+                          setEditingBooking((prev) => prev ? ({ ...prev, wallet_discount_amount: Math.min(val, maxWallet) } as any) : prev);
+                        }}
+                        className="flex-1"
+                      />
+                      <div className="text-right">
+                        <p className="text-sm font-bold text-blue-600">
+                          ₹{((editingBooking as any)?.wallet_discount_amount ?? 0).toFixed(2)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
 
                 {/* Pricing Details */}
                 <div className="space-y-3 rounded-lg bg-gray-50 p-4">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -1953,6 +1953,49 @@ const AdminBookingManagement: React.FC = () => {
                   </div>
                 </div>
 
+                {/* Customer Wallet Balance */}
+                {editingBooking?.customer_id && (
+                  <div className="mb-4 rounded-lg bg-blue-50 border border-blue-200 p-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1">
+                        <label className="block text-sm font-semibold text-gray-900 mb-2">
+                          👛 Customer Wallet Balance
+                        </label>
+                        <p className="text-xs text-gray-600 mb-3">
+                          View and manage customer's available wallet credits
+                        </p>
+                        <div className="grid grid-cols-2 gap-3 mb-3">
+                          <div className="bg-white rounded p-2">
+                            <p className="text-xs text-gray-600">Current Balance</p>
+                            <p className="text-lg font-bold text-blue-600">
+                              ₹{((editingBooking as any)?.customer_wallet_balance ?? 0).toFixed(2)}
+                            </p>
+                          </div>
+                          <div className="bg-white rounded p-2">
+                            <p className="text-xs text-gray-600">Total Earned</p>
+                            <p className="text-lg font-bold text-green-600">
+                              ₹{((editingBooking as any)?.customer_total_earned ?? 0).toFixed(2)}
+                            </p>
+                          </div>
+                        </div>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full text-xs"
+                          onClick={() => {
+                            const customerId = (editingBooking as any)?.customer_id?._id || (editingBooking as any)?.customer_id;
+                            if (customerId) {
+                              window.open(`/wallet?customer=${customerId}`, '_blank');
+                            }
+                          }}
+                        >
+                          View Full Wallet History
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 {/* Pricing Details */}
                 <div className="space-y-3 rounded-lg bg-gray-50 p-4">
                   <div className="flex justify-between">

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -620,7 +620,7 @@ const AdminBookingManagement: React.FC = () => {
       es.addEventListener('booking_change', (event: MessageEvent) => {
         try {
           const payload = JSON.parse(event.data);
-          console.log('�� Received booking_change SSE payload:', payload?._id || payload);
+          console.log('🔔 Received booking_change SSE payload:', payload?._id || payload);
           if (payload && payload._id && !showEditDialog) {
             applyBookingUpdate(payload._id, payload);
 
@@ -2102,7 +2102,8 @@ const AdminBookingManagement: React.FC = () => {
                         vendor: editingBooking.vendor,
                         discount_percent: editingBooking.discount_percent || 0,
                         discount_amount: totals.discountAmount || 0,
-                        cashback_amount: totals.cashbackAmount || 0,
+                        cashback_amount: (editingBooking as any).cashback_amount || 0,
+                        wallet_discount_amount: (editingBooking as any).wallet_discount_amount || 0,
                       };
 
                       if (editingBooking.item_prices && editingBooking.item_prices.length > 0) {

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -323,7 +323,7 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
         {/* Action Buttons */}
         <div className="space-y-3">
           <Button
-            onClick={onConfirmBooking}
+            onClick={() => onConfirmBooking(walletAmountToApply)}
             disabled={isProcessing}
             className="w-full bg-green-600 hover:bg-green-700 py-3 text-white font-semibold"
           >
@@ -333,7 +333,7 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
                 Confirming...
               </div>
             ) : (
-              `Confirm Booking - $${pricing.finalAmount.toFixed(2)}`
+              `Confirm Booking - ₹${finalAmountAfterWallet.toFixed(2)}`
             )}
           </Button>
 

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -48,6 +48,37 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
     currentUser,
   } = bookingData;
 
+  const [walletBalance, setWalletBalance] = useState(0);
+  const [walletAmountToApply, setWalletAmountToApply] = useState(0);
+  const [loadingWallet, setLoadingWallet] = useState(false);
+
+  useEffect(() => {
+    const fetchWalletBalance = async () => {
+      setLoadingWallet(true);
+      try {
+        const response = await fetch("/api/wallet/balance", {
+          headers: {
+            "Authorization": `Bearer ${localStorage.getItem("userToken")}`,
+          },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (data.success && data.data?.wallet) {
+            setWalletBalance(data.data.wallet.balance || 0);
+          }
+        }
+      } catch (error) {
+        console.error("Failed to fetch wallet balance:", error);
+      } finally {
+        setLoadingWallet(false);
+      }
+    };
+
+    if (currentUser) {
+      fetchWalletBalance();
+    }
+  }, [currentUser]);
+
   const calculatePricing = () => {
     let basePrice = 0;
 
@@ -77,6 +108,7 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
   };
 
   const pricing = calculatePricing();
+  const finalAmountAfterWallet = Math.max(0, pricing.finalAmount - walletAmountToApply);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { Input } from "@/components/ui/input";
 import {
   CheckCircle,
   Calendar,
@@ -11,6 +12,7 @@ import {
   DollarSign,
   User,
   ArrowLeft,
+  Wallet,
 } from "lucide-react";
 
 interface BookingConfirmationProps {
@@ -24,7 +26,7 @@ interface BookingConfirmationProps {
     provider?: { name: string; image?: string; price?: number };
     currentUser: any;
   };
-  onConfirmBooking: () => void;
+  onConfirmBooking: (walletAmountToApply?: number) => void;
   onBack: () => void;
   isProcessing: boolean;
 }

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -56,16 +56,25 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
     const fetchWalletBalance = async () => {
       setLoadingWallet(true);
       try {
+        const token = localStorage.getItem("cleancare_token");
+        if (!token) {
+          console.warn("No auth token found");
+          setLoadingWallet(false);
+          return;
+        }
+
         const response = await fetch("/api/wallet/balance", {
           headers: {
-            "Authorization": `Bearer ${localStorage.getItem("userToken")}`,
+            "Authorization": `Bearer ${token}`,
           },
         });
         if (response.ok) {
           const data = await response.json();
-          if (data.success && data.data?.wallet) {
-            setWalletBalance(data.data.wallet.balance || 0);
+          if (data.success && data.wallet) {
+            setWalletBalance(data.wallet.balance || 0);
           }
+        } else if (response.status === 401) {
+          console.warn("Wallet fetch - Unauthorized. Token may be expired.");
         }
       } catch (error) {
         console.error("Failed to fetch wallet balance:", error);
@@ -248,7 +257,7 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
 
                 <div className="space-y-2">
                   <label className="text-xs font-semibold text-gray-700">
-                    Apply Wallet Amount (₹)
+                    Apply Wallet Credit (₹)
                   </label>
                   <Input
                     type="number"

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -56,9 +56,9 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
     const fetchWalletBalance = async () => {
       setLoadingWallet(true);
       try {
-        const token = localStorage.getItem("cleancare_token");
+        const token = localStorage.getItem("auth_token");
         if (!token) {
-          console.warn("No auth token found");
+          console.warn("No auth token found in localStorage");
           setLoadingWallet(false);
           return;
         }
@@ -75,6 +75,8 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
           }
         } else if (response.status === 401) {
           console.warn("Wallet fetch - Unauthorized. Token may be expired.");
+        } else {
+          console.warn(`Wallet fetch error: ${response.status}`);
         }
       } catch (error) {
         console.error("Failed to fetch wallet balance:", error);

--- a/src/components/BookingConfirmation.tsx
+++ b/src/components/BookingConfirmation.tsx
@@ -219,12 +219,106 @@ const BookingConfirmation: React.FC<BookingConfirmationProps> = ({
               )}
               <Separator className="my-2" />
               <div className="flex justify-between font-bold">
-                <span>Total Amount</span>
+                <span>Subtotal</span>
                 <span>${pricing.finalAmount.toFixed(2)}</span>
               </div>
             </div>
           </CardContent>
         </Card>
+
+        {/* Wallet Balance Card */}
+        {walletBalance > 0 && (
+          <Card className="mb-6 border-blue-200 bg-blue-50">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center text-sm">
+                <Wallet className="w-4 h-4 mr-2 text-blue-600" />
+                Use Wallet Balance
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <div className="space-y-3">
+                <div className="flex justify-between items-center p-2 bg-blue-100 rounded">
+                  <span className="text-sm font-medium text-blue-900">
+                    Available Balance
+                  </span>
+                  <span className="text-lg font-bold text-blue-700">
+                    ${walletBalance.toFixed(2)}
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold text-gray-700">
+                    Apply Wallet Amount (₹)
+                  </label>
+                  <Input
+                    type="number"
+                    min="0"
+                    max={Math.min(walletBalance, pricing.finalAmount)}
+                    step="0.01"
+                    value={walletAmountToApply}
+                    onChange={(e) => {
+                      const value = parseFloat(e.target.value) || 0;
+                      const maxAmount = Math.min(walletBalance, pricing.finalAmount);
+                      setWalletAmountToApply(Math.min(value, maxAmount));
+                    }}
+                    placeholder="0.00"
+                    className="w-full"
+                  />
+                </div>
+
+                {walletAmountToApply > 0 && (
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        setWalletAmountToApply(
+                          Math.min(walletBalance, pricing.finalAmount),
+                        )
+                      }
+                      className="flex-1 text-xs"
+                    >
+                      Use Max
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setWalletAmountToApply(0)}
+                      className="flex-1 text-xs"
+                    >
+                      Clear
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Final Amount Card */}
+        {walletAmountToApply > 0 && (
+          <Card className="mb-6 border-green-200 bg-green-50">
+            <CardContent className="pt-4">
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span>Subtotal</span>
+                  <span>${pricing.finalAmount.toFixed(2)}</span>
+                </div>
+                <div className="flex justify-between text-green-600">
+                  <span>Wallet Discount</span>
+                  <span>-${walletAmountToApply.toFixed(2)}</span>
+                </div>
+                <Separator className="my-2" />
+                <div className="flex justify-between font-bold text-lg text-green-700">
+                  <span>Final Amount</span>
+                  <span>${finalAmountAfterWallet.toFixed(2)}</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Action Buttons */}
         <div className="space-y-3">

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -334,7 +334,7 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
           provider,
           currentUser,
         }}
-        onConfirmBooking={handleBookService}
+        onConfirmBooking={(walletAmount) => handleBookService(walletAmount || 0)}
         onBack={() => setShowConfirmation(false)}
         isProcessing={isProcessing}
       />

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -181,6 +181,9 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
             },
           ];
 
+      const baseAmount = calculateFinalAmount();
+      const finalAmountAfterWallet = Math.max(0, baseAmount - walletAmountToApply);
+
       const bookingData = {
         customer_id: customerId,
         service: isMultipleServices
@@ -214,7 +217,8 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
           .filter(Boolean)
           .join("\n"),
         total_price: calculateTotalPrice(),
-        final_amount: calculateFinalAmount(),
+        final_amount: finalAmountAfterWallet,
+        wallet_applied_amount: walletAmountToApply,
 
         special_instructions: [
           additionalDetails,
@@ -239,7 +243,7 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
         // For backward compatibility with different booking systems
         pickupDate: selectedDate.toISOString().split("T")[0],
         pickupTime: selectedTime,
-        totalAmount: calculateFinalAmount(),
+        totalAmount: finalAmountAfterWallet,
         userId: customerId,
         paymentStatus: "pending",
         status: "pending",

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -104,8 +104,8 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
 
 
 
-  const handleBookService = async () => {
-    console.log("🚀 Starting booking process...");
+  const handleBookService = async (walletAmountToApply: number = 0) => {
+    console.log("🚀 Starting booking process with wallet amount:", walletAmountToApply);
     bookingTestHelper.runDiagnostic();
 
     if (!currentUser) {


### PR DESCRIPTION
This pull request introduces the functionality for customers to use their wallet balance towards the cost of a new booking.

### Key Changes:

#### Backend

- **Booking Model (`Booking.js`)**: 
  - Added `wallet_applied_amount` to store the amount paid from the wallet.
  - Added `wallet_payment_processed` to track if the wallet deduction was successful.

- **Bookings Route (`bookings.js`)**:
  - The booking creation endpoint now handles `wallet_applied_amount`.
  - If a wallet amount is applied, the system deducts it from the user's wallet, updates their balance, and creates a debit transaction record.

#### Frontend (Customer Flow)

- **Booking Confirmation (`BookingConfirmation.tsx`)**:
  - Fetches and displays the user's available wallet balance.
  - Provides an input for the user to apply wallet funds to the booking.
  - Displays the subtotal, wallet discount, and the final amount to be paid.

- **Booking Flow (`BookingFlow.tsx`)**:
  - The booking creation logic now sends the `wallet_applied_amount` to the backend.
  - The `final_amount` is adjusted to reflect the wallet discount.

#### Frontend (Admin Panel)

- **Admin Booking Management (`AdminBookingManagement.tsx`)**:
  - When viewing a booking, a new section displays the customer's current wallet balance and total earned credits.
  - Includes a button to link directly to the customer's full wallet history page.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/41545fcfb65748839abe68af4d55a741/quantum-haven)

👀 [Preview Link](https://41545fcfb65748839abe68af4d55a741-quantum-haven.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>41545fcfb65748839abe68af4d55a741</projectId>-->
<!--<branchName>quantum-haven</branchName>-->