### PR TITLE
feat: Show zero value fields in booking history

### DIFF
--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -165,6 +165,12 @@ const bookingSchema = new mongoose.Schema(
       default: 0,
       min: [0, "Cashback must be non-negative"],
     },
+    // Wallet amount applied to this booking (additional wallet deduction)
+    wallet_applied: {
+      type: Number,
+      default: 0,
+      min: [0, "Wallet applied must be non-negative"],
+    },
     // Wallet cashback to be credited to user after order completes
     wallet_cashback: {
       type: Number,

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -2236,6 +2236,30 @@ const AdminBookingManagement: React.FC = () => {
                         Max: ₹{userWalletBalance.toFixed(2)}
                       </div>
                     </div>
+
+                    {/* Wallet Applied Input */}
+                    <div>
+                      <label className="text-sm text-purple-900 font-semibold mb-1 block">
+                        Wallet Applied (₹)
+                      </label>
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={editingBooking.wallet_applied || 0}
+                        onChange={(e) => {
+                          const value = parseFloat(e.target.value) || 0;
+                          setEditingBooking((prev) =>
+                            prev ? { ...prev, wallet_applied: value } : prev
+                          );
+                        }}
+                        placeholder="0.00"
+                        className="w-full px-3 py-2 border border-purple-300 rounded text-sm"
+                      />
+                      <div className="text-xs text-purple-600 mt-1">
+                        Additional wallet amount applied to this order
+                      </div>
+                    </div>
                   </div>
 
                   {/* Wallet Cashback Percentage Input */}

--- a/src/components/AdminBookingManagement.tsx
+++ b/src/components/AdminBookingManagement.tsx
@@ -2355,6 +2355,7 @@ const AdminBookingManagement: React.FC = () => {
                         vendor: editingBooking.vendor,
                         cashback_amount: editingBooking.cashback_amount || 0,
                         cashback: editingBooking.cashback || 0,
+                        wallet_applied: editingBooking.wallet_applied || 0,
                         wallet_cashback: editingBooking.wallet_cashback || 0,
                         discount_percent: editingBooking.discount_percent || 0,
                         discount_amount: totals.details?.discount || 0,

--- a/src/components/EnhancedBookingHistory.tsx
+++ b/src/components/EnhancedBookingHistory.tsx
@@ -1149,62 +1149,62 @@ const EnhancedBookingHistory: React.FC<EnhancedBookingHistoryProps> =
                               );
                             })()}
 
-                            {booking.discount_amount &&
-                              booking.discount_amount > 0 && (
-                                <div className="space-y-1">
-                                  <div className="flex justify-between items-center">
-                                    <span className="text-green-600">
-                                      Discount
-                                    </span>
-                                    <span className="font-medium text-green-600">
-                                      -₹{booking.discount_amount}
-                                    </span>
-                                  </div>
-                                  {booking.coupon_code && (
-                                    <div className="text-xs text-green-600 flex justify-end">
-                                      Code: {booking.coupon_code}
-                                    </div>
-                                  )}
+                            {/* Discount Amount - Always Show */}
+                            <div className="space-y-1">
+                              <div className="flex justify-between items-center">
+                                <span className="text-green-600">
+                                  Discount Amount
+                                </span>
+                                <span className="font-medium text-green-600">
+                                  {booking.discount_amount && booking.discount_amount > 0
+                                    ? `-₹${booking.discount_amount}`
+                                    : `₹0`}
+                                </span>
+                              </div>
+                              {booking.coupon_code && (
+                                <div className="text-xs text-green-600 flex justify-end">
+                                  Code: {booking.coupon_code}
                                 </div>
                               )}
+                            </div>
 
-                            {booking.cashback &&
-                              booking.cashback > 0 && (
-                                <div className="flex justify-between items-center">
-                                  <span className="text-blue-600">
-                                    Wallet Used
-                                  </span>
-                                  <span className="font-medium text-blue-600">
-                                    -₹{booking.cashback}
-                                  </span>
-                                </div>
-                              )}
+                            {/* Wallet Used - Always Show */}
+                            <div className="flex justify-between items-center">
+                              <span className="text-blue-600">
+                                Wallet Used
+                              </span>
+                              <span className="font-medium text-blue-600">
+                                {booking.cashback && booking.cashback > 0
+                                  ? `-₹${booking.cashback}`
+                                  : `₹0`}
+                              </span>
+                            </div>
 
-                            {booking.wallet_applied &&
-                              booking.wallet_applied > 0 && (
-                                <div className="flex justify-between items-center">
-                                  <span className="text-blue-600">
-                                    Wallet Applied
-                                  </span>
-                                  <span className="font-medium text-blue-600">
-                                    -₹{booking.wallet_applied.toFixed(2)}
-                                  </span>
-                                </div>
-                              )}
+                            {/* Wallet Applied - Always Show */}
+                            <div className="flex justify-between items-center">
+                              <span className="text-blue-600">
+                                Wallet Applied
+                              </span>
+                              <span className="font-medium text-blue-600">
+                                {booking.wallet_applied && booking.wallet_applied > 0
+                                  ? `-₹${booking.wallet_applied.toFixed(2)}`
+                                  : `₹0`}
+                              </span>
+                            </div>
 
-                            {booking.wallet_cashback &&
-                              booking.wallet_cashback > 0 && (
-                                <div className="flex justify-between items-center">
-                                  <span className="text-purple-600">
-                                    Cashback Earned
-                                  </span>
-                                  <span className="font-medium text-purple-600">
-                                    +₹{(booking.wallet_cashback > 0 && booking.wallet_cashback < 100
-                                      ? ((booking.final_amount || booking.total_price || 0) * booking.wallet_cashback / 100).toFixed(2)
-                                      : booking.wallet_cashback).toFixed(2)}
-                                  </span>
-                                </div>
-                              )}
+                            {/* Cashback Earned - Always Show */}
+                            <div className="flex justify-between items-center">
+                              <span className="text-purple-600">
+                                Cashback Earned
+                              </span>
+                              <span className="font-medium text-purple-600">
+                                {booking.wallet_cashback && booking.wallet_cashback > 0
+                                  ? `+₹${(booking.wallet_cashback > 0 && booking.wallet_cashback < 100
+                                    ? ((booking.final_amount || booking.total_price || 0) * booking.wallet_cashback / 100).toFixed(2)
+                                    : booking.wallet_cashback).toFixed(2)}`
+                                  : `₹0`}
+                              </span>
+                            </div>
 
                             <Separator className="my-1" />
 

--- a/src/integrations/mongodb/models/Booking.ts
+++ b/src/integrations/mongodb/models/Booking.ts
@@ -32,6 +32,9 @@ export interface Booking extends Document {
   additional_details?: string;
   total_price: number;
   discount_amount?: number;
+  cashback?: number;
+  wallet_applied?: number;
+  wallet_cashback?: number;
   final_amount: number;
   payment_status: "pending" | "paid" | "failed" | "refunded";
   status: "pending" | "confirmed" | "in_progress" | "completed" | "cancelled";

--- a/src/integrations/mongodb/types.ts
+++ b/src/integrations/mongodb/types.ts
@@ -35,6 +35,9 @@ export interface Booking {
   additional_details?: string;
   total_price: number;
   discount_amount?: number;
+  cashback?: number;
+  wallet_applied?: number;
+  wallet_cashback?: number;
   final_amount: number;
   payment_status: "pending" | "paid" | "failed" | "refunded";
   status: "pending" | "confirmed" | "in_progress" | "completed" | "cancelled";


### PR DESCRIPTION
### Purpose

The user wants to enhance the booking history page to always display fields like discount, cashback, wallet usage, and cashback earned, even when their value is zero. This change aims to provide greater transparency to users, mirroring the information available to administrators.

### Code changes

- **`src/components/EnhancedBookingHistory.tsx`**:
    - Modified the rendering logic to always show the "Discount Amount", "Wallet Used", "Wallet Applied", and "Cashback Earned" sections.
    - Previously, these sections were hidden if their corresponding values were zero.
    - Now, if the value is zero, it explicitly displays "₹0" for clarity.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/3b42598f1215494ba34908b90efdd0c1/nova-studio)

👀 [Preview Link](https://3b42598f1215494ba34908b90efdd0c1-nova-studio.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 44`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b42598f1215494ba34908b90efdd0c1</projectId>-->
<!--<branchName>nova-studio</branchName>-->