### PR TITLE
Prevent booking status change on vehicle allocation

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -2709,7 +2709,7 @@ router.post("/order-allocation/allocate", verifyAdminAccess, async (req, res) =>
     // Update booking with vehicle assignment
     booking.assigned_vehicle_id = vehicle_id;
     booking.vehicle_time_slot = slot_start_time || null;
-    booking.status = "vehicle_allocated"; // Update booking status
+    // Note: Do not update status here - allocation is an operational detail, not a workflow state change
 
     await vehicle.save();
     await booking.save();


### PR DESCRIPTION
## Summary
This PR prevents the booking status from automatically updating to "vehicle_allocated" when a vehicle is assigned to a booking.

## Problem
The user reported an error occurring after selecting a vehicle. The previous logic incorrectly treated vehicle allocation as a workflow state change by updating the `booking.status`. This likely caused invalid state transitions or downstream errors in the application flow.

## Solution
The line responsible for updating `booking.status` to "vehicle_allocated" has been removed. A comment was added to clarify that vehicle allocation is an operational detail and should not trigger a workflow state change.

## Key Changes
- Removed the assignment `booking.status = "vehicle_allocated"` in the allocation logic.
- Added code comments clarifying the intent.

## Files Changed
- `backend/routes/admin.js`: Modified the `/order-allocation/allocate` route to preserve the existing booking status during vehicle assignment.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/6da8fe9045cd47098b9717396ba02d25/mystic-landing)

👀 [Preview Link](https://6da8fe9045cd47098b9717396ba02d25-mystic-landing.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 70`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6da8fe9045cd47098b9717396ba02d25</projectId>-->
<!--<branchName>mystic-landing</branchName>-->